### PR TITLE
Revert "config: deploy only Merge Request"

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -3,12 +3,8 @@ name: Deploy Hugo site to Pages
 
 on:
   # Runs on pushes targeting the default branch
-  #  push:
-  #    branches: ["master"]
-  pull_request:
-    # Sequence of patterns matched against refs/heads
-    branches:
-      - master
+  push:
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Reverts betabrandao/betabrandao.github.io#21

Acredito que causei uma falha de semântica quando inclui no trigger o merge request para master, já que a branch está protegida.

Mas o trigger push to master não faz sentido ser executado em um merge, mas vou testar, vai que esteja errada